### PR TITLE
Integrate amethyst-imgui for debug UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,8 +1644,8 @@ name = "libterrain"
 version = "0.1.0"
 dependencies = [
  "nalgebra 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "noise 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "noise 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1904,11 +1904,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "noise"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "image 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2346,15 +2346,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3249,6 +3240,7 @@ dependencies = [
  "amethyst-imgui 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdwarf 0.1.0",
  "libterrain 0.1.0",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "specs-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3903,7 +3895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
-"checksum noise 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a3a34d4f8a31f95919b7ead9f5b60afb9bda0cae98b9219432ffaa6f00b0141"
+"checksum noise 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "337525774dd8a197b613a01ea88058ef0ed023e5ed1e4b7e93de478e1f2bf770"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
@@ -3952,7 +3944,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9c35d9c36a562f37eca96e79f66d5fd56eefbc22560dacc4a864cabd2d277456"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "amethyst-imgui"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amethyst 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-winit-support 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "amethyst_animation"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1423,34 @@ dependencies = [
  "png 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "imgui"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "imgui-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "imgui-winit-support"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2749,6 +2790,7 @@ dependencies = [
  "rendy-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shaderc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3021,6 +3063,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "shaderc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shaderc-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shaderc-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,6 +3246,7 @@ name = "stone-cunning"
 version = "0.1.0"
 dependencies = [
  "amethyst 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amethyst-imgui 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdwarf 0.1.0",
  "libterrain 0.1.0",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3656,6 +3717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum alga_derive 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f448d7130355515534b7d3af3aa8524365de18b11bbd1deceb06a5956c435f0b"
 "checksum alsa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b0edcbbf9ef68f15ae1b620f722180b82a98b6f0628d30baa6b8d2a5abc87d58"
 "checksum amethyst 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "35696e553fda82c2c6c6c35d4575e35ff31908df737bde93d40f33bf2fe5d4c9"
+"checksum amethyst-imgui 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d1ffda7cb9656b46df8cdad6ca94ed4a0dcf9abe66271d55f2ae6a970e95631e"
 "checksum amethyst_animation 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91be72a4247dd2273398c39edb49cba9b02dc46a6f92352926480b077a68081f"
 "checksum amethyst_assets 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad24404cb3f321dfb95e171359235737400f222fd39e1a43b5518ac1d8e9184d"
 "checksum amethyst_audio 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90d29d25ed8e0ee992522ed898d2569fc4f576e77afa02306d08f8906d5b768a"
@@ -3790,6 +3852,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
 "checksum image 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "545f000e8aa4e569e93f49c446987133452e0091c2494ac3efd3606aa3d309f2"
 "checksum image 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)" = "35371e467cd7b0b3d1d6013d619203658467df12d61b0ca43cd67b743b1965eb"
+"checksum imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e70a1b421ac503e94009cc9bcd6ed256f6bf38ced98d841b095da6b94ea67702"
+"checksum imgui-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0350b22f0a64eeb852ed3995ddb5d6d24bd3038024d2bd81720a6573baa602dc"
+"checksum imgui-winit-support 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c63c45c058634dbc045dde485a7baf0f4321b77c00cca90c5d2d9b3ab2f5eec"
 "checksum inflate 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f9f47468e9a76a6452271efadc88fe865a82be91fe75e6c0c57b87ccea59d4"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum intl_pluralrules 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f4cbf667b8cb0fec29160019036a35851da8fb8731de904734da66fd5087174"
@@ -3954,6 +4019,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
 "checksum servo-fontconfig-sys 4.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b46d201addcfbd25c1798ad1281d98c40743824e0b0f1e611bd3d5d0d31a7b8d"
 "checksum servo-freetype-sys 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4ccb6d0d32d277d3ef7dea86203d8210945eb7a45fba89dd445b3595dd0dfc"
+"checksum shaderc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7edff43a83e12343b7908b4ee4cef1c886460fc721d868ee69d6a45ae902c22"
+"checksum shaderc-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a3d04ede135a5d6d66451f6ed501da68f8a63e0477185ab4e7d459cd78a6e34"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum shred 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6ea122e6133568144fcfb5888737d4ac776ebc959f989dd65b907136ac22bfed"
 "checksum shred 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d15d46c92f8c0aed110a132f3c68a8cdd390048f51fa547c89dc571ba1e01191"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ libterrain = { path = "libterrain" }
 version = "0.13.0"
 features = ["metal"]
 
+[dependencies.amethyst-imgui]
+version = "0.5.1"
+# amethyst-imgui by default uses vulkan, however since we
+# primarily work in OSX, we need to turn this off.
+default-features = false
+
 [workspace]
 members = [
     # Worker/object sim.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+log = "0.4.8"
 rand = "0.7.2"
 serde = "1.0.101"
 specs-derive = "0.4.0"

--- a/libdwarf/src/components/mod.rs
+++ b/libdwarf/src/components/mod.rs
@@ -1,6 +1,5 @@
 use libterrain::Point3;
 use specs::{Component, VecStorage};
-use specs_derive::*;
 
 mod object;
 mod resource;

--- a/libdwarf/src/components/object.rs
+++ b/libdwarf/src/components/object.rs
@@ -1,5 +1,4 @@
 use specs::{Component, VecStorage};
-use specs_derive::*;
 use std::collections::VecDeque;
 
 use crate::{

--- a/libpath/Cargo.toml
+++ b/libpath/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Andrew Huynh <a5thuynh@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-nalgebra = "0.18.0"
-rand = "0.7.0"
+nalgebra = { version = "0.18.1", features = ["serde-serialize", "mint"] }
+rand = "0.7.2"
 libterrain = { path = "../libterrain" }

--- a/libterrain/Cargo.toml
+++ b/libterrain/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Andrew Huynh <a5thuynh@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-nalgebra = "0.18.0"
-noise = "0.5.1"
-rand = "0.6.5"
+nalgebra = { version = "0.18.1", features = ["serde-serialize", "mint"] }
+noise = "0.6.0"
+rand = "0.7.2"

--- a/libterrain/src/lib.rs
+++ b/libterrain/src/lib.rs
@@ -54,7 +54,7 @@ impl TerrainGenerator {
                 // Ground level is always at 32.
                 let biome = self.determine_biome(elevation);
                 let terrain_height =
-                    GROUND_HEIGHT + (f64::from(GROUND_HEIGHT) * elevation).floor() as u32;
+                    (GROUND_HEIGHT as f64 + (f64::from(GROUND_HEIGHT) * elevation).floor()) as u32;
 
                 heightmap[y * self.width + x] = Some((terrain_height, biome.clone()));
 

--- a/libterrain/src/poisson.rs
+++ b/libterrain/src/poisson.rs
@@ -110,7 +110,6 @@ impl PoissonDisk {
     pub fn generate(&mut self, new_points_count: usize) {
         let mut rng = rand::thread_rng();
         // Generate other points from points in queue
-        println!("generating points");
         while !self.active.is_empty() {
             let idx = (rng.gen::<f64>() * (self.active.len() - 1) as f64) as usize;
             let point = self.active[idx];
@@ -131,7 +130,5 @@ impl PoissonDisk {
                 self.active.remove(idx);
             }
         }
-
-        println!("finished generating points: ({})", self.samples.len());
     }
 }

--- a/resources/ui/debug.ron
+++ b/resources/ui/debug.ron
@@ -10,85 +10,6 @@ Container(
     children: [
         Container(
             transform: (
-                id: "task_panel",
-                anchor: TopLeft,
-                x: 96.0,
-                y: -200.0,
-                width: 192.0,
-                height: 400.0,
-            ),
-            background: SolidColor(1.0, 1.0, 1.0, 0.5),
-            children: [
-                Button(
-                    transform: (
-                        id: "add_worker_btn",
-                        y: -40.,
-                        stretch: X(x_margin: 8),
-                        height: 64.,
-                        tab_order: 0,
-                        anchor: TopMiddle,
-                        mouse_reactive: true,
-                    ),
-                    button: (
-                        text: "Add Worker",
-                        font: File("resources/fonts/PxPlus_IBM_VGA8.ttf", ("TTF", ())),
-                        font_size: 20.,
-                        normal_text_color: (1.0, 0.85, 0.4, 1.0),
-                        hover_text_color: (1.0, 0.85, 0.4, 1.0),
-                        press_text_color: (0.0, 0.0, 0.0, 1.0),
-                        normal_image: SolidColor(0.17, 0.16, 0.18, 1.0),
-                        hover_image: SolidColor(0.25, 0.24, 0.26, 1.0),
-                        press_image: SolidColor(1., 1., 1., 1.),
-                    )
-                ),
-                Button(
-                    transform: (
-                        id: "add_resource_btn",
-                        y: -112.,
-                        stretch: X(x_margin: 8),
-                        height: 64.,
-                        tab_order: 1,
-                        anchor: TopMiddle,
-                        mouse_reactive: true,
-                    ),
-                    button: (
-                        text: "Add Resource",
-                        font: File("resources/fonts/PxPlus_IBM_VGA8.ttf", ("TTF", ())),
-                        font_size: 20.,
-                        normal_text_color: (1.0, 0.85, 0.4, 1.0),
-                        hover_text_color: (1.0, 0.85, 0.4, 1.0),
-                        press_text_color: (0.0, 0.0, 0.0, 1.0),
-                        normal_image: SolidColor(0.17, 0.16, 0.18, 1.0),
-                        hover_image: SolidColor(0.25, 0.24, 0.26, 1.0),
-                        press_image: SolidColor(1., 1., 1., 1.),
-                    )
-                ),
-                Button(
-                    transform: (
-                        id: "add_task_btn",
-                        y: -184.,
-                        stretch: X(x_margin: 8),
-                        height: 64.,
-                        tab_order: 1,
-                        anchor: TopMiddle,
-                        mouse_reactive: true,
-                    ),
-                    button: (
-                        text: "Add Task",
-                        font: File("resources/fonts/PxPlus_IBM_VGA8.ttf", ("TTF", ())),
-                        font_size: 20.,
-                        normal_text_color: (1.0, 0.85, 0.4, 1.0),
-                        hover_text_color: (1.0, 0.85, 0.4, 1.0),
-                        press_text_color: (0.0, 0.0, 0.0, 1.0),
-                        normal_image: SolidColor(0.17, 0.16, 0.18, 1.0),
-                        hover_image: SolidColor(0.25, 0.24, 0.26, 1.0),
-                        press_image: SolidColor(1., 1., 1., 1.),
-                    )
-                ),
-            ],
-        ),
-        Container(
-            transform: (
                 id: "game_info",
                 anchor: TopRight,
                 x: -100.0,
@@ -115,37 +36,6 @@ Container(
                     )
                 ),
             ]
-        ),
-        Container(
-            transform: (
-                id: "debug_panel",
-                anchor: TopRight,
-                x: -200.0,
-                y: -264.0,
-                width: 400.0,
-                height: 400.0,
-            ),
-            background: SolidColor(1.0, 1.0, 1.0, 0.5),
-            children: [
-                Label(
-                    transform: (
-                        id: "debug_info",
-                        x: 216.0,
-                        y: -40.,
-                        anchor: TopLeft,
-                        stretch: XY(x_margin: 0., y_margin: 0., keep_aspect_ratio: false),
-                        transparent: true,
-                    ),
-                    text: (
-                        text: "Nothing Selected",
-                        font: File("resources/fonts/PxPlus_IBM_VGA8.ttf", ("TTF", ())),
-                        font_size: 20.,
-                        line_mode: Wrap,
-                        align: MiddleLeft,
-                        color: (0.0, 0.0, 0.0, 1.0),
-                    )
-                ),
-            ]
-        ),
+        )
     ],
 )

--- a/src/game/render/map.rs
+++ b/src/game/render/map.rs
@@ -4,6 +4,7 @@ use amethyst::{
     prelude::*,
     renderer::{SpriteRender, Transparent},
 };
+
 use libdwarf::resources::Map;
 use libterrain::Biome;
 
@@ -39,8 +40,6 @@ impl MapRenderer {
             (map.terrain.clone(), map.width, map.height)
         };
 
-        // Create terrain
-        println!("Map dims: ({}, {})", width, height);
         for y in 0..height {
             for x in 0..width {
                 for z in 32..64 {

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -9,6 +9,8 @@ use amethyst::{
     window::DisplayConfig,
     winit::{Event, MouseScrollDelta, WindowEvent},
 };
+use log::info;
+use std::time::SystemTime;
 
 use libdwarf::{actions::Action, resources::TaskQueue, world::WorldSim, Point3};
 use libterrain::TerrainGenerator;
@@ -46,7 +48,11 @@ impl SimpleState for RunningState {
         };
 
         // Initialize simulation
+        info!("Generating map w/ dims: ({}, {})", map_width, map_height);
+        let now = SystemTime::now();
         let terrain_gen = TerrainGenerator::new(map_width, map_height).build();
+        info!("Terrain gen took: {}ms", now.elapsed().unwrap().as_millis());
+
         WorldSim::new(world, &terrain_gen.get_terrain(), map_width, map_height);
         // Render map
         let map_render = MapRenderer::initialize(world);

--- a/src/game/systems/ui/debug.rs
+++ b/src/game/systems/ui/debug.rs
@@ -26,6 +26,22 @@ impl<'s> System<'s> for DebugUI {
 
     fn run(&mut self, (entities, objects, workers, cursor_selected, mut queue): Self::SystemData) {
         amethyst_imgui::with(|ui| {
+            Window::new(im_str!("Tasks"))
+                .size([300.0, 500.0], Condition::FirstUseEver)
+                .build(ui, || {
+                    if ui.collapsing_header(im_str!("world")).build() {
+                        for action in queue.world.iter() {
+                            ui.text(&im_str!("{:?}", action));
+                        }
+                    }
+
+                    if ui.collapsing_header(im_str!("worker")).build() {
+                        for action in queue.worker.iter() {
+                            ui.text(&im_str!("{:?}", action));
+                        }
+                    }
+                });
+
             Window::new(im_str!("Workers"))
                 .size([300.0, 100.0], Condition::FirstUseEver)
                 .build(ui, || {

--- a/src/game/systems/ui/debug.rs
+++ b/src/game/systems/ui/debug.rs
@@ -1,6 +1,4 @@
-use amethyst::{
-    ecs::{Entities, ReadExpect, ReadStorage, System, Write},
-};
+use amethyst::ecs::{Entities, Join, ReadExpect, ReadStorage, System, Write};
 use amethyst_imgui::imgui::{im_str, Condition, Window};
 
 use libdwarf::{
@@ -13,7 +11,10 @@ use libdwarf::{
 use crate::game::components::CursorSelected;
 
 #[derive(Default)]
-pub struct DebugUI;
+pub struct DebugUI {
+    new_worker_pos: [i32; 3],
+}
+
 impl<'s> System<'s> for DebugUI {
     type SystemData = (
         Entities<'s>,
@@ -23,34 +24,32 @@ impl<'s> System<'s> for DebugUI {
         Write<'s, TaskQueue>,
     );
 
-    fn run(
-        &mut self,
-        (
-            entities,
-            objects,
-            workers,
-            cursor_selected,
-            mut queue,
-        ): Self::SystemData,
-    ) {
+    fn run(&mut self, (entities, objects, workers, cursor_selected, mut queue): Self::SystemData) {
         amethyst_imgui::with(|ui| {
             Window::new(im_str!("Workers"))
                 .size([300.0, 100.0], Condition::FirstUseEver)
                 .build(ui, || {
+                    ui.input_int3(im_str!("map pos"), &mut self.new_worker_pos)
+                        .build();
+
                     if ui.button(im_str!("Add Worker"), [0.0, 0.0]) {
-                        queue.add_world(Action::AddWorker(Point3::new(1, 1, 0)));
+                        queue.add_world(Action::AddWorker(Point3::new(
+                            self.new_worker_pos[0] as u32,
+                            self.new_worker_pos[1] as u32,
+                            self.new_worker_pos[2] as u32,
+                        )));
                     }
 
-                    if ui.button(im_str!("Add Resource"), [0.0, 0.0]) {
-                        queue.add_world(Action::Add(Point3::new(9, 9, 0), String::from("tree")));
-                    }
+                    ui.separator();
 
-                    if ui.button(im_str!("Add Task"), [0.0, 0.0]) {
-                        queue.add(Action::HarvestResource(
-                            Point3::new(9, 9, 0),
-                            String::from("tree"),
-                            String::from("wood"),
-                        ));
+                    for (entity, worker) in (&entities, &workers).join() {
+                        if ui
+                            .collapsing_header(&im_str!("Worker {}", entity.id()))
+                            .build()
+                        {
+                            ui.text(&im_str!("action queue: {}", worker.actions.len()));
+                            ui.text(&im_str!("inventory: {}", worker.inventory.len()));
+                        }
                     }
                 });
 
@@ -59,38 +58,50 @@ impl<'s> System<'s> for DebugUI {
                 .build(ui, || {
                     let selected = &cursor_selected.hover_selected;
                     if let Some(pick_info) = selected {
-                        let worker_label = pick_info.worker
+                        let worker_label = pick_info
+                            .worker
                             .and_then(|worker_id| {
                                 let entity = entities.entity(worker_id);
                                 workers.get(entity)
                             })
-                            .and_then(|worker| Some(format!("worker: {}", worker.to_string())))
-                            .unwrap_or("worker: N/A".to_string());
+                            .and_then(|worker| Some(format!("Worker: {}", worker.to_string())))
+                            .unwrap_or("Worker: N/A".to_string());
                         ui.text(worker_label);
 
-                        let object_label = pick_info.object
+                        let object_label = pick_info
+                            .object
                             .and_then(|object_id| {
                                 let entity = entities.entity(object_id);
                                 objects.get(entity)
                             })
-                            .and_then(|object| Some(format!("object: {}", object.to_string())))
-                            .unwrap_or("object: N/A".to_string());
+                            .and_then(|object| Some(format!("Object: {}", object.to_string())))
+                            .unwrap_or("Object: N/A".to_string());
                         ui.text(object_label);
 
-                        let terrain_label = pick_info.terrain.as_ref()
-                            .and_then(|terrain| Some(format!("terrain: {:?}", terrain)))
-                            .unwrap_or("terrain: N/A".to_string());
+                        let terrain_label = pick_info
+                            .terrain
+                            .as_ref()
+                            .and_then(|terrain| Some(format!("Terrain: {:?}", terrain)))
+                            .unwrap_or("Terrain: N/A".to_string());
                         ui.text(terrain_label);
 
-                        let map_pos = pick_info.position
+                        let map_pos = pick_info
+                            .position
                             .and_then(|position| {
-                                Some(format!("pos: ({}, {}, {})", position.x, position.y, position.z))
+                                Some(format!(
+                                    "Map Pos: ({}, {}, {})",
+                                    position.x, position.y, position.z
+                                ))
                             })
-                            .unwrap_or("pos: N/A".to_string());
+                            .unwrap_or("Map Pos: N/A".to_string());
                         ui.text(map_pos);
 
                         let mouse_pos = ui.io().mouse_pos;
-                        ui.text(im_str!("Mouse Position: ({:.1},{:.1})", mouse_pos[0], mouse_pos[1]));
+                        ui.text(im_str!(
+                            "Mouse Pos: ({:.1},{:.1})",
+                            mouse_pos[0],
+                            mouse_pos[1]
+                        ));
                     }
                 });
         });

--- a/src/game/systems/ui/debug.rs
+++ b/src/game/systems/ui/debug.rs
@@ -47,9 +47,15 @@ impl<'s> System<'s> for DebugUI {
                             .collapsing_header(&im_str!("Worker {}", entity.id()))
                             .build()
                         {
-                            ui.text(&im_str!("action queue: {}", worker.actions.len()));
                             ui.text(&im_str!("inventory: {}", worker.inventory.len()));
+                            if ui.collapsing_header(im_str!("Action Queue")).build() {
+                                for action in worker.actions.iter() {
+                                    ui.text(&im_str!("{:?}", action));
+                                }
+                            }
                         }
+
+                        ui.separator();
                     }
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ use game::{
 };
 
 fn main() -> amethyst::Result<()> {
-    amethyst::start_logger(Default::default());
+    amethyst::Logger::from_config(Default::default())
+        .level_for("gfx_backend_metal", amethyst::LogLevelFilter::Warn)
+        .start();
 
     let app_root = application_root_dir()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use amethyst::{
     utils::{application_root_dir, fps_counter::FpsCounterBundle},
     window::DisplayConfig,
 };
+use amethyst_imgui::RenderImgui;
 
 use libdwarf::systems;
 
@@ -54,7 +55,8 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.0, 0.0, 0.0, 1.0]),
                 )
                 .with_plugin(RenderFlat2D::default())
-                .with_plugin(RenderUi::default()),
+                .with_plugin(RenderUi::default())
+                .with_plugin(RenderImgui::<StringBindings>::default()),
         )?
         // Simulation systems.
         .with(systems::AssignTaskSystem, "assign_task", &[])


### PR DESCRIPTION
- [x] Add `amethyst-imgui` dependency.
- [x] Version match similar dependencies (`rand`, `serde`, `nalgebra`).
- [x] Replace old debug UI w/ imgui counterparts.
- [x] Add a new window to view world/worker tasks queue.